### PR TITLE
Please update each app to latest SDK and fix installing from SimFinger

### DIFF
--- a/Fake/FakeYouTube/FakePhone.xcodeproj/project.pbxproj
+++ b/Fake/FakeYouTube/FakePhone.xcodeproj/project.pbxproj
@@ -121,7 +121,14 @@
 			isa = PBXProject;
 			buildConfigurationList = C01FCF4E08A954540054247B /* Build configuration list for PBXProject "FakePhone" */;
 			compatibilityVersion = "Xcode 3.1";
+			developmentRegion = English;
 			hasScannedForEncodings = 1;
+			knownRegions = (
+				English,
+				Japanese,
+				French,
+				German,
+			);
 			mainGroup = 29B97314FDCFA39411CA2CEA /* CustomTemplate */;
 			projectDirPath = "";
 			projectRoot = "";
@@ -192,7 +199,7 @@
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				PREBINDING = NO;
-				SDKROOT = iphoneos2.2;
+				SDKROOT = iphoneos;
 			};
 			name = Debug;
 		};
@@ -205,7 +212,7 @@
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				PREBINDING = NO;
-				SDKROOT = iphoneos2.2;
+				SDKROOT = iphoneos;
 			};
 			name = Release;
 		};


### PR DESCRIPTION
Right now installing from SimFinger gives this when the app is started (see end of this message) after it crashes... Installing the single apps from within their Xcode projects works though. I tried to figure out why but couldn't

Also it might be a good idea to pull some of the forks who have nice features like https://github.com/qrunchmonkey/SimFinger for example.

Cheers

---- console :
11/27/10 1:14:37 PM UIKitApplication:com.yourcompany.YouTube[0xe03e][6848]  objc[6848]: found old-ABI metadata in image /Users/mc/Library/Application Support/iPhone Simulator/4.2/Applications/FakeYouTube/YouTube.app/YouTube !
11/27/10 1:14:37 PM com.apple.launchd.peruser.502[191](UIKitApplication:com.yourcompany.YouTube[0xe03e][6848]) Job appears to have crashed: Segmentation fault
11/27/10 1:14:37 PM com.apple.launchd.peruser.502[191](UIKitApplication:com.yourcompany.YouTube[0xe03e]) Throttling respawn: Will start in 2147483647 seconds
11/27/10 1:14:37 PM SpringBoard[6844]   Application 'YouTube' exited abnormally with signal 11: Segmentation fault
